### PR TITLE
 Replacing hardcoded generic values with enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "equal-vue",
-  "version": "0.4.1",
+  "version": "0.41.0",
   "author": {
     "name": "Yan Savinov",
     "email": "yan.savinov.hire@gmail.com"

--- a/src/components/alert/ItAlert.vue
+++ b/src/components/alert/ItAlert.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
+import { Colors } from '../../models'
 import './alert.less'
 
 @Component

--- a/src/components/alert/ItAlert.vue
+++ b/src/components/alert/ItAlert.vue
@@ -25,14 +25,19 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
 import './alert.less'
 
 @Component
 export default class ItAlert extends Vue {
   @Prop({
-    default: 'primary',
-    validator: (value) =>
-      ['primary', 'success', 'danger', 'warning'].includes(value)
+    default: Colors.PRIMARY,
+    validator: (value) => [
+      Colors.PRIMARY,
+      Colors.SUCCESS,
+      Colors.DANGER,
+      Colors.WARNING
+    ].includes(value)
   })
   private type?: string
   @Prop({ type: Boolean, default: true }) private showIcon?: boolean

--- a/src/components/badge/ItBadge.vue
+++ b/src/components/badge/ItBadge.vue
@@ -16,8 +16,8 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
-import { Positions } from '@/models/Positions'
+import { Colors } from '../../models'
+import { Positions } from '../../models'
 import './badge.less'
 
 @Component

--- a/src/components/badge/ItBadge.vue
+++ b/src/components/badge/ItBadge.vue
@@ -16,18 +16,24 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
+import { Positions } from '@/models/Positions'
 import './badge.less'
 
 @Component
 export default class ItBadge extends Vue {
   @Prop({
-    default: 'danger',
-    validator: (value) =>
-      ['primary', 'success', 'danger', 'warning'].includes(value)
+    default: Colors.DANGER,
+    validator: (value) => [
+      Colors.PRIMARY,
+      Colors.SUCCESS,
+      Colors.DANGER,
+      Colors.WARNING
+    ].includes(value)
   })
   public type: string
   @Prop() public value: number | string
-  @Prop({ default: 'top-right' }) public position!: string
+  @Prop({ default: Positions.TR }) public position!: string
   @Prop({ type: Boolean, default: true }) public show!: boolean
   @Prop({ type: Boolean, default: false }) public point!: boolean
   @Prop({ type: Boolean, default: false }) public square!: boolean

--- a/src/components/button/ItButton.vue
+++ b/src/components/button/ItButton.vue
@@ -49,20 +49,30 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import './button.less'
+import { Sizes } from '@/models/Sizes'
+import { Colors } from '@/models/Colors'
 
 @Component
 export default class ItButton extends Vue {
   @Prop({
-    default: 'neutral',
-    validator: (value) =>
-      ['primary', 'success', 'danger', 'warning', 'black', 'neutral'].includes(
-        value
-      )
+    default: Colors.NEUTRAL,
+    validator: (value) => [
+        Colors.PRIMARY,
+        Colors.SUCCESS,
+        Colors.DANGER,
+        Colors.WARNING,
+        Colors.BLACK,
+        Colors.NEUTRAL
+      ].includes(value)
   })
   private type!: string
   @Prop({
     default: 'normal',
-    validator: (value) => ['small', 'normal', 'big'].includes(value)
+    validator: (value) => [
+      Sizes.SMALL,
+      Sizes.NORMAL,
+      Sizes.BIG
+    ].includes(value)
   })
   private size?: string
   @Prop({ type: Boolean, default: false }) private iconAfter!: boolean

--- a/src/components/button/ItButton.vue
+++ b/src/components/button/ItButton.vue
@@ -49,8 +49,8 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import './button.less'
-import { Sizes } from '@/models/Sizes'
-import { Colors } from '@/models/Colors'
+import { Sizes } from '../../models'
+import { Colors } from '../../models'
 
 @Component
 export default class ItButton extends Vue {

--- a/src/components/checkbox/ItCheckbox.vue
+++ b/src/components/checkbox/ItCheckbox.vue
@@ -19,11 +19,12 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Model } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
 import './checkbox.less'
 
 @Component
 export default class ItCheckbox extends Vue {
-  @Prop({ default: 'primary' }) private type!: string
+  @Prop({ default: Colors.PRIMARY }) private type!: string
   @Prop({ default: 'check' }) private icon!: string
   @Prop({ type: Boolean, default: false }) private pulse!: boolean
   @Prop({ type: Boolean, default: false }) private lineThrough!: boolean
@@ -32,7 +33,14 @@ export default class ItCheckbox extends Vue {
   @Prop({ type: Boolean, default: false }) private disabled?: boolean
   @Prop() private color!: string // TODO
 
-  private types: string[] = ['primary', 'success', 'danger', 'warning', 'black', 'neutral']
+  private types: Colors[] = [
+    Colors.PRIMARY,
+    Colors.SUCCESS,
+    Colors.DANGER,
+    Colors.WARNING,
+    Colors.BLACK,
+    Colors.NEUTRAL
+  ]
 
   get listeners() {
     return {

--- a/src/components/checkbox/ItCheckbox.vue
+++ b/src/components/checkbox/ItCheckbox.vue
@@ -19,7 +19,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Model } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
+import { Colors } from '../../models'
 import './checkbox.less'
 
 @Component

--- a/src/components/dropdown/ItDropdown.vue
+++ b/src/components/dropdown/ItDropdown.vue
@@ -21,27 +21,28 @@
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import PopoverMixin from '../../mixins/popover'
 import './dropdown.less'
+import { Positions } from '../../models/Positions'
 
 @Component({
   mixins: [PopoverMixin]
 })
 export default class ItDropdown extends Vue {
   @Prop({
-    default: 'bottom',
+    default: Positions.B,
     validator: (value) =>
       [
-        'bottom',
-        'bottom-left',
-        'bottom-right',
-        'left',
-        'left-top',
-        'left-bottom',
-        'right',
-        'right-top',
-        'right-bottom',
-        'top',
-        'top-left',
-        'top-right'
+        Positions.B,
+        Positions.BL,
+        Positions.BR,
+        Positions.L,
+        Positions.LT,
+        Positions.LB,
+        Positions.R,
+        Positions.RT,
+        Positions.RB,
+        Positions.T,
+        Positions.TL,
+        Positions.TR
       ].includes(value)
   })
   private placement!: string

--- a/src/components/dropdown/ItDropdown.vue
+++ b/src/components/dropdown/ItDropdown.vue
@@ -21,7 +21,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import PopoverMixin from '../../mixins/popover'
 import './dropdown.less'
-import { Positions } from '../../models/Positions'
+import { Positions } from '../../models'
 
 @Component({
   mixins: [PopoverMixin]

--- a/src/components/input/ItInput.vue
+++ b/src/components/input/ItInput.vue
@@ -38,6 +38,7 @@
 
 <script lang="ts">
 import { Component, Prop, Model, Vue } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
 import './input.less'
 
 @Component({
@@ -51,7 +52,11 @@ export default class ItInput extends Vue {
   @Prop() private suffix?: string
   @Prop({ type: Boolean, default: false }) private disabled?: boolean
   @Prop({
-    validator: (value) => ['success', 'warning', 'danger'].includes(value)
+    validator: (value) => [
+      Colors.SUCCESS,
+      Colors.WARNING,
+      Colors.DANGER
+    ].includes(value)
   })
   private status?: string
   @Prop() private suffixIcon?: string

--- a/src/components/input/ItInput.vue
+++ b/src/components/input/ItInput.vue
@@ -38,7 +38,7 @@
 
 <script lang="ts">
 import { Component, Prop, Model, Vue } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
+import { Colors } from '../../models'
 import './input.less'
 
 @Component({

--- a/src/components/modal/ItModal.vue
+++ b/src/components/modal/ItModal.vue
@@ -28,7 +28,7 @@
 
 <script lang="ts">
 import { Component, Emit, Prop, Model, Vue } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
+import { Colors } from '../../models'
 import FocusLock from 'vue-focus-lock'
 import './modal.less'
 

--- a/src/components/modal/ItModal.vue
+++ b/src/components/modal/ItModal.vue
@@ -28,6 +28,7 @@
 
 <script lang="ts">
 import { Component, Emit, Prop, Model, Vue } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
 import FocusLock from 'vue-focus-lock'
 import './modal.less'
 
@@ -43,7 +44,7 @@ export default class ItModal extends Vue {
   @Prop({ type: Function, default: null }) public okClick?: () => void
   @Prop({ type: Function, default: null }) public cancelClick?: () => void
   @Prop({ type: Boolean, default: true }) public closeOnEsc?: boolean
-  @Prop({ default: 'primary' }) public type?: string
+  @Prop({ default: Colors.PRIMARY }) public type?: string
 
   public activeElement: HTMLElement
 
@@ -52,7 +53,7 @@ export default class ItModal extends Vue {
   public mounted() {
     this.value = true
     document.addEventListener('keydown', this.escEvt)
-    document.body.classList.add('stop-scroll');
+    document.body.classList.add('stop-scroll')
     // this.$refs.cancelButton.$el.focus()
   }
 

--- a/src/components/progressbar/ItProgressbar.vue
+++ b/src/components/progressbar/ItProgressbar.vue
@@ -25,6 +25,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
+import { Positions } from '@/models/Positions'
 import PopoverMixin from '../../mixins/popover'
 import './progressbar.less'
 
@@ -37,7 +38,7 @@ export default class ItProgressbar extends Vue {
   })
   private progress?: number | string
   @Prop({ default: 7 }) private height?: number | string
-  @Prop({ default: 'top' }) private tooltip?: string
+  @Prop({ default: Positions.T }) private tooltip?: string
   @Prop({ type: Boolean, default: true }) private showTooltip?: boolean
 
   @Watch('tooltip')

--- a/src/components/progressbar/ItProgressbar.vue
+++ b/src/components/progressbar/ItProgressbar.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
-import { Positions } from '@/models/Positions'
+import { Positions } from '../../models'
 import PopoverMixin from '../../mixins/popover'
 import './progressbar.less'
 

--- a/src/components/radio/ItRadio.vue
+++ b/src/components/radio/ItRadio.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Model } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
+import { Colors } from '../../models'
 import './radio.less'
 
 @Component

--- a/src/components/radio/ItRadio.vue
+++ b/src/components/radio/ItRadio.vue
@@ -22,11 +22,12 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Model } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
 import './radio.less'
 
 @Component
 export default class ItRadio extends Vue {
-  @Prop({ default: 'primary' }) private type!: string
+  @Prop({ default: Colors.PRIMARY }) private type!: string
   @Prop({ type: Boolean, default: false }) private pulse!: boolean
   @Prop() private label?: string
   @Prop() private value!: string
@@ -34,7 +35,13 @@ export default class ItRadio extends Vue {
 
   @Model('change') private checked!: string
 
-  private types: string[] = ['primary', 'success', 'danger', 'warning', 'black']
+  private types: string[] = [
+    Colors.PRIMARY,
+    Colors.SUCCESS,
+    Colors.DANGER,
+    Colors.WARNING,
+    Colors.BLACK
+  ]
 
   get isChecked() {
     return this.checked === this.value

--- a/src/components/select/ItSelect.vue
+++ b/src/components/select/ItSelect.vue
@@ -51,6 +51,7 @@
 
 <script lang="ts">
 import { Component, Prop, Watch, Vue, Provide, Model } from 'vue-property-decorator'
+import { Positions } from '@/models/Positions'
 import clickoutside from '../../directives/clickOutside'
 import PopoverMixin from '../../mixins/popover'
 import './select.less'
@@ -59,33 +60,33 @@ import './select.less'
   directives: { clickoutside }
 })
 export default class ItSelect extends PopoverMixin {
-  @Prop({ default: 'bottom' }) public placement?: string
+  @Prop({ default: Positions.B }) public placement?: string
   @Prop({ type: Boolean, default: false }) public disabled!: boolean
   @Prop({ type: Boolean, default: false }) public filterable!: boolean
   @Provide() private select = this.selectOption
   @Prop() private labelTop?: string
   @Prop({ default: 'Select' }) private placeholder?: string
 
-  @Model('input') private value?: (string | number)[] | number | string
+  @Model('input') private value?: Array<string | number> | number | string
 
   private selected: any = this.value
   private search: string | number = ''
   private focusIndex: number = -1
 
   @Watch('search')
-  onSearchInput(newVal) {
+  public onSearchInput(newVal) {
     if (!this.show) {
       this.showTooltip()
     }
     this.unfocus()
-    this.$children.forEach(i => {
+    this.$children.forEach((i) => {
       if (!i.$slots.default[0].text.toLowerCase().includes(newVal.toLowerCase())) {
         i.$data.visible = false
       } else {
         i.$data.visible = true
       }
     })
-    
+
   }
 
   private handleKey(type: 'up' | 'down') {
@@ -109,7 +110,7 @@ export default class ItSelect extends PopoverMixin {
   }
 
   get searched() {
-    return this.$children.filter(i => i.$data.visible === true)
+    return this.$children.filter((i) => i.$data.visible === true)
   }
 
   private toggleList() {

--- a/src/components/select/ItSelect.vue
+++ b/src/components/select/ItSelect.vue
@@ -51,7 +51,7 @@
 
 <script lang="ts">
 import { Component, Prop, Watch, Vue, Provide, Model } from 'vue-property-decorator'
-import { Positions } from '@/models/Positions'
+import { Positions } from '../../models'
 import clickoutside from '../../directives/clickOutside'
 import PopoverMixin from '../../mixins/popover'
 import './select.less'

--- a/src/components/switch/ItSwitch.vue
+++ b/src/components/switch/ItSwitch.vue
@@ -24,7 +24,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Model } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
+import { Colors } from '../../models'
 import './switch.less'
 
 @Component

--- a/src/components/switch/ItSwitch.vue
+++ b/src/components/switch/ItSwitch.vue
@@ -24,17 +24,24 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Model } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
 import './switch.less'
 
 @Component
 export default class ItSwitch extends Vue {
-  @Prop({ default: 'primary' }) private type!: string
+  @Prop({ default: Colors.PRIMARY }) private type!: string
   @Prop() private label?: string
   @Prop({ type: Boolean, default: false }) private pulse!: boolean
   @Model('change', { default: false }) private value!: boolean | string | number
   @Prop({ type: Boolean, default: false }) private disabled?: boolean
 
-  private types: string[] = ['primary', 'success', 'danger', 'warning', 'black']
+  private types: string[] = [
+    Colors.PRIMARY,
+    Colors.SUCCESS,
+    Colors.DANGER,
+    Colors.WARNING,
+    Colors.BLACK
+  ]
 
   get listeners() {
     return {

--- a/src/components/tag/ItTag.vue
+++ b/src/components/tag/ItTag.vue
@@ -7,7 +7,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
-import { Colors } from '@/models/Colors'
+import { Colors } from '../../models'
 import './tag.less'
 
 @Component

--- a/src/components/tag/ItTag.vue
+++ b/src/components/tag/ItTag.vue
@@ -7,6 +7,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Colors } from '@/models/Colors'
 import './tag.less'
 
 @Component
@@ -16,11 +17,15 @@ export default class ItTag extends Vue {
 
   public show = true
   @Prop({
-    default: 'neutral',
-    validator: (value) =>
-      ['primary', 'success', 'danger', 'warning', 'black', 'neutral'].includes(
-        value
-      )
+    default: Colors.NEUTRAL,
+    validator: (value) => [
+      Colors.PRIMARY,
+      Colors.SUCCESS,
+      Colors.DANGER,
+      Colors.WARNING,
+      Colors.BLACK,
+      Colors.NEUTRAL
+    ].includes(value)
   })
   private type?: string
 

--- a/src/models/Colors.ts
+++ b/src/models/Colors.ts
@@ -1,0 +1,8 @@
+export enum Colors {
+  NEUTRAL = 'neutral',
+  PRIMARY = 'primary',
+  SUCCESS = 'success',
+  DANGER = 'danger',
+  WARNING = 'warning',
+  BLACK = 'black'
+}

--- a/src/models/Positions.ts
+++ b/src/models/Positions.ts
@@ -1,3 +1,15 @@
 export enum Positions {
+  TR = 'top-right',
+  B = 'bottom',
+  BL = 'bottom-left',
+  BR = 'bottom-right',
+  L = 'left',
+  LT = 'left-top',
+  LB = 'left-bottom',
+  R = 'right',
+  RT = 'right-top',
+  RB = 'right-bottom',
+  T = 'top',
+  TL = 'top-left',
   TR = 'top-right'
 }

--- a/src/models/Positions.ts
+++ b/src/models/Positions.ts
@@ -1,5 +1,4 @@
 export enum Positions {
-  TR = 'top-right',
   B = 'bottom',
   BL = 'bottom-left',
   BR = 'bottom-right',

--- a/src/models/Positions.ts
+++ b/src/models/Positions.ts
@@ -1,0 +1,3 @@
+export enum Positions {
+  TR = 'top-right'
+}

--- a/src/models/Sizes.ts
+++ b/src/models/Sizes.ts
@@ -1,0 +1,5 @@
+export enum Sizes {
+  BIG = 'big',
+  NORMAL = 'normal',
+  SMALL = 'small'
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,5 @@
+import { Colors } from './Colors'
+import { Positions } from './Positions'
+import { Sizes } from './Sizes'
+
+export { Colors, Positions, Sizes }


### PR DESCRIPTION
I think this approach is more __flexible__. Component code will be __easier to maintain__ in the future. Less typos. It is more pleasant to write code, because all available options, for example, colors are suggested by the IDE.
