### PR TITLE
Change active tabs component font-weight without changing containing element width

### DIFF
--- a/src/components/tabs/ItTabs.vue
+++ b/src/components/tabs/ItTabs.vue
@@ -31,6 +31,7 @@
           'it-tabs-tab--disabled': tab.disabled,
         }"
         :disabled="tab.disabled"
+        :data-content="tab.title"
       >
         {{ tab.title }}
       </button>

--- a/src/components/tabs/tabs.less
+++ b/src/components/tabs/tabs.less
@@ -1,6 +1,6 @@
 @import '../../styles/variables.less';
 
-.it-tabs {
+.it-tabs {  
   display: flex;
   flex-direction: column;
 
@@ -83,6 +83,15 @@
       &::after {
         transform: scaleY(2);
       }
+    }
+
+    &::before {
+      display: block;
+      content: attr(data-content);
+      font-weight: 600;
+      height: 0;
+      overflow: hidden;
+      visibility: hidden;
     }
 
     &::after {

--- a/src/components/tabs/tabs.less
+++ b/src/components/tabs/tabs.less
@@ -1,6 +1,6 @@
 @import '../../styles/variables.less';
 
-.it-tabs {  
+.it-tabs {
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
When a new tab becomes active in the tabs component, the layout shifts as the new tab becomes bold.
This PR adds hidden text content before the class, "it-tabs-tab", so that the size of the button does not change when active.


P.S. Thanks for the great library! Makes me want learn/use Vue for my next project!