### PR TITLE
Fixing issue #230

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     }
   },
   "unpkg": "dist/equal.umd.min.js",
+  "types": "src/types/index.d.ts",
   "private": false,
   "license": "MIT",
   "bugs": "https://github.com/quatrochan/Equal/issues",
@@ -23,6 +24,10 @@
     "type": "git",
     "url": "https://github.com/quatrochan/Equal"
   },
+  "files": [
+    "src",
+    "dist"
+  ],
   "keywords": [
     "equal",
     "vue",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'equal-vue';


### PR DESCRIPTION
Related to #230 

Added a couple lines to your package.json

`  "types": "src/types/index.d.ts",`
will point to a new file with a module declaration. Webstorm is looking for that line.

`  "files": [
    "src",
    "dist"
  ],`

This will make it so that when you run `npm publish` it will only gzip these two directories instead of the whole thing. I believe you could even send dist alone but providing the src directory helps when people want to read the component's code.